### PR TITLE
fix: credential leaks, silent restore data-loss, task races; add webhook driver

### DIFF
--- a/apps/strolt/internal/dmanager/notification.go
+++ b/apps/strolt/internal/dmanager/notification.go
@@ -8,6 +8,7 @@ import (
 	"github.com/strolt/strolt/apps/strolt/internal/driver/notification/console"
 	"github.com/strolt/strolt/apps/strolt/internal/driver/notification/slack"
 	"github.com/strolt/strolt/apps/strolt/internal/driver/notification/telegram"
+	"github.com/strolt/strolt/apps/strolt/internal/driver/notification/webhook"
 	"github.com/strolt/strolt/shared/logger"
 )
 
@@ -17,18 +18,18 @@ type Notification string
 // Supported notification drivers.
 const (
 	DriverNotificationConsole  Notification = "console"
-	DriverNotificationEmail    Notification = "email"
 	DriverNotificationSlack    Notification = "slack"
 	DriverNotificationTelegram Notification = "telegram"
+	DriverNotificationWebhook  Notification = "webhook"
 )
 
 // GetAvailableDriverNotification returns the supported notification drivers.
 func GetAvailableDriverNotification() []Notification {
 	return []Notification{
 		DriverNotificationConsole,
-		DriverNotificationEmail,
 		DriverNotificationSlack,
 		DriverNotificationTelegram,
+		DriverNotificationWebhook,
 	}
 }
 
@@ -43,6 +44,7 @@ func GetNotificationDriver(driver Notification, serviceName string, taskName str
 		DriverNotificationConsole:  console.New(),
 		DriverNotificationSlack:    slack.New(slack.Params{}),
 		DriverNotificationTelegram: telegram.New(telegram.Params{}),
+		DriverNotificationWebhook:  webhook.New(),
 	}
 
 	d, ok := notificationDrivers[driver]

--- a/apps/strolt/internal/driver/destination/restic/init.go
+++ b/apps/strolt/internal/driver/destination/restic/init.go
@@ -25,8 +25,6 @@ func (i *Restic) Init() error {
 
 	i.logger.Debug(cmd.String())
 
-	i.logger.Debug(cmd.Env)
-
 	output, err := cmd.CombinedOutput()
 	i.logger.Debug(string(output))
 

--- a/apps/strolt/internal/driver/notification/email/email.go
+++ b/apps/strolt/internal/driver/notification/email/email.go
@@ -1,2 +1,0 @@
-// Package email is a placeholder for an email notification driver.
-package email

--- a/apps/strolt/internal/driver/notification/notifyutil/notifyutil.go
+++ b/apps/strolt/internal/driver/notification/notifyutil/notifyutil.go
@@ -1,0 +1,21 @@
+// Package notifyutil provides shared helpers for notification drivers.
+package notifyutil
+
+import (
+	"errors"
+	"net/url"
+)
+
+// RedactURLError removes the request URL from an *url.Error so that secrets
+// embedded in notification endpoints (Telegram bot tokens, Slack webhook paths,
+// custom webhook URLs) are not written to logs. HTTP client calls such as
+// http.Post return an *url.Error whose Error() includes the full request URL;
+// logging it verbatim would leak the secret to any log sink.
+func RedactURLError(err error) error {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		urlErr.URL = "[redacted]"
+	}
+
+	return err
+}

--- a/apps/strolt/internal/driver/notification/slack/slack.go
+++ b/apps/strolt/internal/driver/notification/slack/slack.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/strolt/strolt/apps/strolt/internal/context"
+	"github.com/strolt/strolt/apps/strolt/internal/driver/notification/notifyutil"
 	"github.com/strolt/strolt/shared/logger"
 
 	"gopkg.in/yaml.v3"
@@ -77,7 +78,9 @@ func (i *Slack) Send(ctx context.Context) {
 
 	resp, err := http.Post(i.getWebhook(), "application/json", body) //nolint:noctx
 	if err != nil {
-		i.logger.Error(err)
+		// The transport error embeds the request URL, which is the secret
+		// webhook; redact it before logging.
+		i.logger.Error(notifyutil.RedactURLError(err))
 		return
 	}
 

--- a/apps/strolt/internal/driver/notification/telegram/telegram.go
+++ b/apps/strolt/internal/driver/notification/telegram/telegram.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/strolt/strolt/apps/strolt/internal/context"
+	"github.com/strolt/strolt/apps/strolt/internal/driver/notification/notifyutil"
 	"github.com/strolt/strolt/shared/logger"
 
 	"gopkg.in/yaml.v3"
@@ -77,7 +78,9 @@ func (i *Telegram) Send(ctx context.Context) {
 
 	resp, err := http.Post(i.getURL(), "application/json", body) //nolint:noctx
 	if err != nil {
-		i.logger.Error(err)
+		// The transport error embeds the request URL, which contains the bot
+		// token; redact it before logging.
+		i.logger.Error(notifyutil.RedactURLError(err))
 		return
 	}
 

--- a/apps/strolt/internal/driver/notification/telegram/template.go
+++ b/apps/strolt/internal/driver/notification/telegram/template.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"html"
 
 	"github.com/strolt/strolt/apps/strolt/internal/context"
 	"github.com/strolt/strolt/apps/strolt/internal/template"
@@ -18,8 +19,13 @@ type telegramMsg struct {
 func getTemplate(ctx context.Context) (*bytes.Buffer, error) {
 	t := template.New("telegram", ctx)
 
-	msg := fmt.Sprintf("<b>%s</b>", t.Header)
-	msg += "\n\n" + t.Body
+	// Header and Body carry dynamic content (service/task names, snapshot IDs
+	// and the operation error text). Escape them so characters like <, > and &
+	// do not form invalid HTML entities that make Telegram reject the message
+	// with HTTP 400 and silently drop the alert. CopyrightHTML is a fixed,
+	// intentional <a> tag and must stay literal.
+	msg := fmt.Sprintf("<b>%s</b>", html.EscapeString(t.Header))
+	msg += "\n\n" + html.EscapeString(t.Body)
 	msg += "\n\n " + t.CopyrightHTML
 
 	body := telegramMsg{Text: msg, ParseMode: "HTML"}

--- a/apps/strolt/internal/driver/notification/webhook/webhook.go
+++ b/apps/strolt/internal/driver/notification/webhook/webhook.go
@@ -1,0 +1,110 @@
+// Package webhook implements a notification driver that posts the raw operation
+// context as JSON to a configured HTTP endpoint.
+package webhook
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/strolt/strolt/apps/strolt/internal/context"
+	"github.com/strolt/strolt/apps/strolt/internal/driver/notification/notifyutil"
+	"github.com/strolt/strolt/shared/logger"
+
+	"gopkg.in/yaml.v3"
+)
+
+// requestTimeout bounds a single webhook delivery so a slow or unresponsive
+// endpoint cannot block the task pipeline indefinitely.
+const requestTimeout = 30 * time.Second
+
+// Config holds the target webhook URL.
+type Config struct {
+	URL string `yaml:"url"`
+}
+
+// Webhook is a notification driver that posts the operation context to a URL.
+type Webhook struct {
+	logger *logger.Logger
+	config Config
+	client *http.Client
+}
+
+// New creates a Webhook driver.
+func New() *Webhook {
+	return &Webhook{
+		client: &http.Client{Timeout: requestTimeout},
+	}
+}
+
+// SetLogger sets the logger used by the driver.
+func (i *Webhook) SetLogger(logger *logger.Logger) {
+	i.logger = logger
+}
+
+// SetConfig parses and validates the driver configuration.
+func (i *Webhook) SetConfig(config any) error {
+	data, err := yaml.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+
+	if err := yaml.Unmarshal(data, &i.config); err != nil {
+		return fmt.Errorf("unmarshal config: %w", err)
+	}
+
+	return validateConfig(i.config)
+}
+
+// Send posts the operation context as JSON to the configured webhook URL.
+func (i *Webhook) Send(ctx context.Context) {
+	data, err := json.Marshal(ctx)
+	if err != nil {
+		i.logger.Error(err)
+		return
+	}
+
+	resp, err := i.client.Post(i.config.URL, "application/json", bytes.NewReader(data)) //nolint:noctx
+	if err != nil {
+		// The transport error embeds the request URL, which may carry a secret
+		// token; redact it before logging.
+		i.logger.Error(notifyutil.RedactURLError(err))
+		return
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	b, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		i.logger.WithField("status", resp.Status).Error(string(b))
+	}
+}
+
+func validateConfig(config Config) error {
+	if config.URL == "" {
+		return errors.New("url is empty")
+	}
+
+	u, err := url.Parse(config.URL)
+	if err != nil {
+		return fmt.Errorf("url is invalid: %w", err)
+	}
+
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return errors.New("url must use the http or https scheme")
+	}
+
+	if u.Host == "" {
+		return errors.New("url has no host")
+	}
+
+	return nil
+}

--- a/apps/strolt/internal/driver/source/local/local.go
+++ b/apps/strolt/internal/driver/source/local/local.go
@@ -85,10 +85,13 @@ func validateEnv(_ Env) error {
 }
 
 // Backup performs a backup of the configured local path.
+//
+// It is intentionally a no-op: for a local source the task work directory is the
+// source path itself (context.setWorkDir sets WorkDir = abs(SourceLocalPath)),
+// so the destination driver reads directly from the source path and there is
+// nothing to copy into a separate work directory. Copying here (WorkDir ==
+// config.Path) would copy the directory onto itself.
 func (i *Local) Backup(_ context.Context) error {
-	// if err := copy.Copy(i.config.Path, ctx.WorkDir); err != nil {
-	// 	return err
-	// }
 	return nil
 }
 
@@ -126,10 +129,13 @@ func (i *Local) IsSupportedBackupPipe(_ context.Context) bool {
 }
 
 // Restore restores a backup to the configured local path.
+//
+// It is intentionally a no-op: for a local source the task work directory is the
+// source path itself (context.setWorkDir sets WorkDir = abs(SourceLocalPath)),
+// so the destination driver restores the snapshot directly into the source path
+// (restic runs `restore --target WorkDir`). Copying here (WorkDir ==
+// config.Path) would copy the directory onto itself.
 func (i *Local) Restore(_ context.Context) error {
-	// if err := copy.Copy(ctx.WorkDir, i.config.Path); err != nil {
-	// 	return err
-	// }
 	return nil
 }
 

--- a/apps/strolt/internal/driver/source/mysql/config.go
+++ b/apps/strolt/internal/driver/source/mysql/config.go
@@ -103,12 +103,15 @@ func (i *MySQL) getBackupArgs() []string {
 func (i *MySQL) getRestoreArgs() []string {
 	commonArgs := i.getCommonArgs()
 
-	args := make([]string, 0, len(commonArgs)+4)
+	args := make([]string, 0, len(commonArgs)+2)
 	args = append(args, commonArgs...)
 
+	// The dump is fed to the client on stdin (see Restore) rather than through
+	// the client-side `source` builtin: in non-interactive batch mode the client
+	// aborts on the first failing statement and returns a non-zero exit code,
+	// while `-e "source ..."` swallows per-statement errors and can exit 0 on a
+	// partial restore.
 	args = append(args, "-D", i.config.Database)
-
-	args = append(args, "-e", "source "+i.getFileName())
 
 	return args
 }

--- a/apps/strolt/internal/driver/source/mysql/restore.go
+++ b/apps/strolt/internal/driver/source/mysql/restore.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/strolt/strolt/apps/strolt/internal/context"
@@ -12,9 +14,23 @@ import (
 
 // Restore runs the mysql client to load the dump from the working directory.
 func (i *MySQL) Restore(ctx context.Context) error {
+	dumpPath := filepath.Join(ctx.WorkDir, i.getFileName())
+
+	dump, err := os.Open(dumpPath) //nolint:gosec // path is built from the driver's own dump file name inside the work dir
+	if err != nil {
+		return fmt.Errorf("open dump file: %w", err)
+	}
+
+	defer func() {
+		_ = dump.Close()
+	}()
+
 	args := i.getRestoreArgs()
 	cmd := exec.Command(i.getBinMySQL(), args...) //nolint:gosec,noctx // arguments come from validated configuration; driver context carries no std context
 	cmd.Dir = ctx.WorkDir
+	// Feed the dump on stdin so the client runs in batch mode and aborts on the
+	// first failing statement with a non-zero exit code.
+	cmd.Stdin = dump
 
 	outputByte, err := cmd.CombinedOutput()
 	outputString := string(outputByte)

--- a/apps/strolt/internal/driver/source/pg/config.go
+++ b/apps/strolt/internal/driver/source/pg/config.go
@@ -118,6 +118,11 @@ func (i *PgDump) getRestoreArgs() []string {
 
 	args = append(args, i.getCommonArgs()...)
 
+	// Abort on the first error so a partial restore (truncated dump, restoring
+	// into a non-empty/mismatched database) fails with a non-zero exit code
+	// instead of silently exiting 0 and being reported as successful.
+	args = append(args, "--exit-on-error")
+
 	return args
 }
 

--- a/apps/strolt/internal/driver/source/pg/restore_psql.go
+++ b/apps/strolt/internal/driver/source/pg/restore_psql.go
@@ -18,6 +18,11 @@ func (i *PgDump) restoreWithPSQLCmd(ctx context.Context, filename string, isPipe
 
 	args := i.getCommonArgs()
 
+	// Abort on the first SQL error so a partial restore returns a non-zero exit
+	// code instead of psql's default of continuing past errors and exiting 0,
+	// which would be reported as a successful restore.
+	args = append(args, "-v", "ON_ERROR_STOP=1")
+
 	if !isPipe {
 		args = append(args, "--file="+filename)
 	}

--- a/apps/strolt/internal/env/env.go
+++ b/apps/strolt/internal/env/env.go
@@ -47,8 +47,6 @@ func Scan() {
 	default:
 		logger.SetLogLevel(logger.LogLevelInfo)
 	}
-
-	logger.SetLogLevel(logger.LogLevelTrace)
 }
 
 // Port returns the configured API port.

--- a/apps/strolt/internal/task/backup.go
+++ b/apps/strolt/internal/task/backup.go
@@ -130,7 +130,7 @@ func (t *Task) backupManual() error {
 		t.eventOperationStop()
 	}
 
-	notificationWaitGroup.Wait()
+	t.notifyWaitGroup().Wait()
 
 	return resultError
 }
@@ -151,7 +151,7 @@ func (t *Task) backupPipe() error {
 		t.eventOperationStop()
 	}
 
-	notificationWaitGroup.Wait()
+	t.notifyWaitGroup().Wait()
 
 	return err
 }

--- a/apps/strolt/internal/task/manager.go
+++ b/apps/strolt/internal/task/manager.go
@@ -1,7 +1,6 @@
 package task
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -42,11 +41,19 @@ var managerVar = manager{
 func (t *Task) managerStart(operation sctxt.OperationType) error {
 	taskKey := t.mangerGetKeyForTask()
 
-	if t.IsRunning() {
-		return t.managerCreateErrorIsRunning()
-	}
-
+	// The running check and the running-flag update must happen inside a single
+	// critical section. Splitting them (check under RLock, set under Lock) leaves
+	// a TOCTOU window in which two goroutines starting the same task both observe
+	// "not running" and both proceed — defeating the whole purpose of the manager.
 	managerVar.Lock()
+	defer managerVar.Unlock()
+
+	if taskItem, ok := managerVar.Tasks[taskKey]; ok && taskItem.IsRunning {
+		return fmt.Errorf(
+			"task '%s' for service '%s' already started '%s' with operation '%s' - trigger '%s'",
+			t.TaskName, t.Context.ServiceName, taskItem.StartedAt.Format(time.RFC3339), taskItem.Opeation, taskItem.TriggerType,
+		)
+	}
 
 	item := ManagerTaskItem{
 		ServiceName: t.Context.ServiceName,
@@ -58,16 +65,13 @@ func (t *Task) managerStart(operation sctxt.OperationType) error {
 		TriggerType: t.Trigger,
 	}
 
-	taskItem, ok := managerVar.Tasks[taskKey]
-	if ok {
+	if taskItem, ok := managerVar.Tasks[taskKey]; ok {
 		item.LastEndedAt = taskItem.LastEndedAt
 	}
 
 	managerVar.Tasks[taskKey] = item
 
 	managerVar.LastChangedAt = time.Now()
-
-	managerVar.Unlock()
 
 	return nil
 }
@@ -136,20 +140,6 @@ func GetManagerStatus() ManagerStatus {
 	status.Tasks = list
 
 	return status
-}
-
-func (t *Task) managerCreateErrorIsRunning() error {
-	managerVar.RLock()
-	defer managerVar.RUnlock()
-
-	taskKey := t.mangerGetKeyForTask()
-
-	taskItem, ok := managerVar.Tasks[taskKey]
-	if !ok {
-		return errors.New("task not found in manager")
-	}
-
-	return fmt.Errorf("task '%s' for service '%s' already started '%s' with operation '%s' - trigger '%s'", t.TaskName, t.Context.ServiceName, taskItem.StartedAt.Format(time.RFC3339), taskItem.Opeation, taskItem.TriggerType)
 }
 
 func (t *Task) mangerGetKeyForTask() string {

--- a/apps/strolt/internal/task/notification.go
+++ b/apps/strolt/internal/task/notification.go
@@ -11,7 +11,16 @@ import (
 	"github.com/strolt/strolt/shared/logger"
 )
 
-var notificationWaitGroup = sync.WaitGroup{}
+// notifyWaitGroup returns this task's notification WaitGroup, creating it on
+// first use. It is only ever accessed from the task's own operation goroutine
+// (events are emitted sequentially), so the lazy initialization needs no lock.
+func (t *Task) notifyWaitGroup() *sync.WaitGroup {
+	if t.notificationWaitGroup == nil {
+		t.notificationWaitGroup = &sync.WaitGroup{}
+	}
+
+	return t.notificationWaitGroup
+}
 
 // SendNotifications sends the current context event to all matching notification drivers.
 func (t *Task) SendNotifications() error {
@@ -40,7 +49,7 @@ func (t *Task) sendNotifications() {
 		return
 	}
 
-	notificationWaitGroup.Go(func() {
+	t.notifyWaitGroup().Go(func() {
 		if err := tCopy.SendNotifications(); err != nil {
 			log := logger.New()
 			log.Warnf("send notification error: %s", err)

--- a/apps/strolt/internal/task/prune.go
+++ b/apps/strolt/internal/task/prune.go
@@ -52,7 +52,7 @@ func (t *Task) Prune(destinationName string, isDryRun bool) ([]interfaces.Snapsh
 		t.eventOperationStop()
 	}
 
-	notificationWaitGroup.Wait()
+	t.notifyWaitGroup().Wait()
 
 	return snapshotList, err
 }
@@ -96,7 +96,7 @@ func (t *Task) PruneAll() error {
 		t.eventOperationStop()
 	}
 
-	notificationWaitGroup.Wait()
+	t.notifyWaitGroup().Wait()
 
 	return resultError
 }

--- a/apps/strolt/internal/task/task.go
+++ b/apps/strolt/internal/task/task.go
@@ -3,6 +3,7 @@ package task
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/strolt/strolt/apps/strolt/internal/config"
 	"github.com/strolt/strolt/apps/strolt/internal/context"
@@ -33,6 +34,12 @@ type Task struct {
 	TaskConfig              config.TaskConfig `json:"taskConfig"`
 	log                     *logger.Logger
 	isNotificationsDisabled bool
+
+	// notificationWaitGroup tracks the in-flight notification goroutines of this
+	// task only. It must be per-task: a package-global would let one task's Add
+	// race another task's Wait, corrupting the barrier and risking a
+	// "WaitGroup misuse" panic when tasks run concurrently.
+	notificationWaitGroup *sync.WaitGroup
 }
 
 // TaskOperation identifies the kind of operation a task performs.

--- a/apps/stroltm/cmd/stroltm/root.go
+++ b/apps/stroltm/cmd/stroltm/root.go
@@ -60,7 +60,11 @@ monitoring their status, and coordinating backup operations across your infrastr
 	Run: func(cmd *cobra.Command, args []string) {
 		log := logger.New()
 
-		log.Info(config.Get())
+		cfg := config.Get()
+		log.Infof(
+			"config loaded: %d api user(s), %d strolt instance(s), %d stroltp instance(s)",
+			len(cfg.API.Users), len(cfg.Strolt.Instances), len(cfg.Stroltp.Instances),
+		)
 
 		ctx, cancel := context.WithCancel(context.Background())
 

--- a/apps/stroltp/cmd/stroltp/root.go
+++ b/apps/stroltp/cmd/stroltp/root.go
@@ -59,7 +59,11 @@ for your distributed backup infrastructure.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log := logger.New()
 
-		log.Info(config.Get())
+		cfg := config.Get()
+		log.Infof(
+			"config loaded: %d api user(s), %d strolt instance(s)",
+			len(cfg.API.Users), len(cfg.Strolt.Instances),
+		)
 
 		ctx, cancel := context.WithCancel(context.Background())
 

--- a/shared/sdk/strolt/strolt.go
+++ b/shared/sdk/strolt/strolt.go
@@ -4,6 +4,7 @@ package strolt
 import (
 	"errors"
 	"fmt"
+	"net/url"
 
 	"github.com/go-openapi/runtime"
 	runtimeClient "github.com/go-openapi/runtime/client"
@@ -20,8 +21,19 @@ type SDK struct {
 }
 
 // New creates an SDK client for the given host with basic auth credentials.
+//
+// host may be a bare "host:port" (defaults to the http scheme, preserving
+// backwards compatibility) or a full URL such as "https://host:port" to enable
+// TLS. Without this, basic-auth credentials would always be sent in cleartext.
 func New(host, username, password string) *SDK {
-	cfg := strolt_client.DefaultTransportConfig().WithHost(host)
+	cfg := strolt_client.DefaultTransportConfig()
+
+	if u, err := url.Parse(host); err == nil && u.Host != "" && (u.Scheme == "http" || u.Scheme == "https") {
+		cfg = cfg.WithHost(u.Host).WithSchemes([]string{u.Scheme})
+	} else {
+		cfg = cfg.WithHost(host)
+	}
+
 	c := strolt_client.NewHTTPClientWithConfig(nil, cfg)
 
 	return &SDK{

--- a/shared/sdk/stroltp/stroltp.go
+++ b/shared/sdk/stroltp/stroltp.go
@@ -4,6 +4,7 @@ package stroltp
 import (
 	"errors"
 	"fmt"
+	"net/url"
 
 	"github.com/go-openapi/runtime"
 	runtimeClient "github.com/go-openapi/runtime/client"
@@ -20,8 +21,19 @@ type SDK struct {
 }
 
 // New creates an SDK client for the given host using basic auth credentials.
+//
+// host may be a bare "host:port" (defaults to the http scheme, preserving
+// backwards compatibility) or a full URL such as "https://host:port" to enable
+// TLS. Without this, basic-auth credentials would always be sent in cleartext.
 func New(host, username, password string) *SDK {
-	cfg := stroltp_client.DefaultTransportConfig().WithHost(host)
+	cfg := stroltp_client.DefaultTransportConfig()
+
+	if u, err := url.Parse(host); err == nil && u.Host != "" && (u.Scheme == "http" || u.Scheme == "https") {
+		cfg = cfg.WithHost(u.Host).WithSchemes([]string{u.Scheme})
+	} else {
+		cfg = cfg.WithHost(host)
+	}
+
 	c := stroltp_client.NewHTTPClientWithConfig(nil, cfg)
 
 	return &SDK{


### PR DESCRIPTION
## Summary

Fixes a set of high-severity findings from a code audit — credential
leaks, silent data-loss on restore, a daemon-crashing concurrency bug —
and adds a raw webhook notification driver.

## Fixes

### Security — credential leaks in logs
- The strolt daemon forced the `TRACE` log level unconditionally, ignoring
  `STROLT_LOG_LEVEL`, which turned every debug-only disclosure into an
  always-on leak. `STROLT_LOG_LEVEL` is honored again.
- `restic init` logged the full command environment (`RESTIC_PASSWORD`,
  cloud keys). Removed.
- stroltm/stroltp logged the entire config (API + instance passwords) at
  startup. Replaced with a non-secret summary.
- Telegram/Slack drivers logged the raw `*url.Error` on transport errors,
  leaking the bot token / secret webhook URL. Redacted via a shared
  `notifyutil.RedactURLError` helper.

### Data loss — restores no longer report false success
- PostgreSQL restore now uses `--exit-on-error` (pg_restore) and
  `-v ON_ERROR_STOP=1` (psql).
- MySQL restore now feeds the dump on stdin in batch mode instead of
  `mysql -e "source ..."`, so it aborts on the first failing statement.
- **Behaviour change:** restoring a plain dump over an existing database
  now fails instead of silently succeeding — the intended behaviour for a
  backup tool.

### Concurrency
- The notification `WaitGroup` was a package global shared by all tasks;
  concurrent tasks could race `Add` against `Wait`, risking a
  `WaitGroup misuse` panic that crashes the daemon. Now per-task.
- `managerStart` checked "is running" and set the running flag under two
  separate locks (TOCTOU), so the same task could start twice. Now a single
  write-locked critical section.

### Correctness
- Telegram messages were sent as HTML with unescaped dynamic content, so a
  `<`, `>` or `&` in the error text (e.g. `<nil>`) made Telegram reject the
  message with HTTP 400 and drop the failure alert. Dynamic parts are now
  escaped.

### Features / cleanup
- New `webhook` notification driver (URL-only config) that POSTs the
  operation context as JSON with a 30s-timeout client.
- Removed the `email` driver: it was advertised as available but never
  registered, so a config using it validated yet failed on every send.

### SDK
- `shared/sdk` strolt/stroltp clients hardcoded the `http` scheme, so
  basic-auth credentials were always sent in cleartext. `New()` now parses
  the host as a URL and honors an `https` scheme, falling back to bare
  `host:port` over http (backwards compatible).

## Note on a false-positive finding

The audit flagged the local **source** `Restore()` no-op as data loss.
While implementing it I traced `context.setWorkDir()`: for a local source
the work directory *is* the source path, so the destination restores the
snapshot directly into it (`restic restore --target WorkDir`) and the
source `Restore()` is correctly a no-op. The proposed "fix"
(`copy.Copy(WorkDir, config.Path)`) would copy a directory onto itself and
break the working restore, so it was **not** applied — the intentional
no-op is now documented instead.

## Verification
- `go build`, `go vet`, `gofmt` clean across all four modules.
- Unit tests pass (strolt / stroltm / stroltp / shared).
- `golangci-lint` on the changed packages: 0 issues.
- An independent adversarial review of the diff surfaced 0 regressions.
