### PR TITLE
feat(strolt): report destination stats for piped backups

### DIFF
--- a/apps/strolt/internal/driver/destination/local/local.go
+++ b/apps/strolt/internal/driver/destination/local/local.go
@@ -125,7 +125,9 @@ func (i *Local) Backup(ctx context.Context) (sctxt.BackupOutput, error) {
 }
 
 // BackupPipe returns a writer that stores the piped backup in a new snapshot directory.
-func (i *Local) BackupPipe(ctx context.Context, filename string) (io.WriteCloser, func() error, error) {
+// The local driver produces no restic-style summary, so its wait func returns an
+// empty BackupOutput; the streamed byte count is filled in by the caller.
+func (i *Local) BackupPipe(ctx context.Context, filename string) (io.WriteCloser, func() (sctxt.BackupOutput, error), error) {
 	snapshotName := uuid.New().String()
 
 	dirpath := path.Join(i.config.Path, snapshotName)
@@ -140,7 +142,7 @@ func (i *Local) BackupPipe(ctx context.Context, filename string) (io.WriteCloser
 		return nil, nil, fmt.Errorf("open snapshot file: %w", err)
 	}
 
-	return writer, func() error { return nil }, nil
+	return writer, func() (sctxt.BackupOutput, error) { return sctxt.BackupOutput{}, nil }, nil
 }
 
 // IsSupportedBackupPipe reports whether piped backups are supported.

--- a/apps/strolt/internal/driver/destination/restic/backup.go
+++ b/apps/strolt/internal/driver/destination/restic/backup.go
@@ -1,14 +1,19 @@
 package restic
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/strolt/strolt/apps/strolt/internal/context"
 	"github.com/strolt/strolt/apps/strolt/internal/sctxt"
 )
+
+const messageTypeSummary = "summary"
 
 type resticBackupOutput struct {
 	MessageType         string  `json:"message_type"` // "summary"
@@ -28,6 +33,49 @@ type resticBackupOutput struct {
 	DryRun              bool    `json:"dry_run,omitempty"`
 }
 
+func (o *resticBackupOutput) toBackupOutput() sctxt.BackupOutput {
+	return sctxt.BackupOutput{
+		FilesNew:            o.FilesNew,
+		FilesChanged:        o.FilesChanged,
+		FilesUnmodified:     o.FilesUnmodified,
+		DirsNew:             o.DirsNew,
+		DirsChanged:         o.DirsChanged,
+		DirsUnmodified:      o.DirsUnmodified,
+		TotalFilesProcessed: o.TotalFilesProcessed,
+		TotalBytesProcessed: o.TotalBytesProcessed,
+		SnapshotID:          o.SnapshotID,
+	}
+}
+
+// parseBackupSummary extracts restic's summary object from its --json backup
+// output. restic prints the summary as the last JSON line, after any status
+// updates, so the scan runs from the end and skips blank trailing lines.
+func parseBackupSummary(output []byte) (sctxt.BackupOutput, error) {
+	lines := strings.Split(string(output), "\n")
+
+	for _, line := range slices.Backward(lines) {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		var summary resticBackupOutput
+		if err := json.Unmarshal([]byte(line), &summary); err != nil {
+			return sctxt.BackupOutput{}, fmt.Errorf("unmarshal backup output: %w", err)
+		}
+
+		// Skip non-summary progress lines (e.g. "status"); accept the summary
+		// message, or a bare object without a message_type for compatibility.
+		if summary.MessageType != "" && summary.MessageType != messageTypeSummary {
+			continue
+		}
+
+		return summary.toBackupOutput(), nil
+	}
+
+	return sctxt.BackupOutput{}, errors.New("restic backup summary not found")
+}
+
 // Backup runs a restic backup of the working directory and returns its summary.
 func (i *Restic) Backup(ctx context.Context) (sctxt.BackupOutput, error) {
 	cmd, err := i.backupCmd(ctx, "", false)
@@ -45,29 +93,20 @@ func (i *Restic) Backup(ctx context.Context) (sctxt.BackupOutput, error) {
 
 	i.logger.Debug(string(output))
 
-	outputs := strings.Split(string(output), "\n")
-
-	var backupOutput resticBackupOutput
-	if err := json.Unmarshal([]byte(outputs[len(outputs)-2]), &backupOutput); err != nil {
+	backupOutput, err := parseBackupSummary(output)
+	if err != nil {
 		i.logger.Error(err)
-		return sctxt.BackupOutput{}, fmt.Errorf("unmarshal backup output: %w", err)
+		return sctxt.BackupOutput{}, err
 	}
 
-	return sctxt.BackupOutput{
-		FilesNew:            backupOutput.FilesNew,
-		FilesChanged:        backupOutput.FilesChanged,
-		FilesUnmodified:     backupOutput.FilesUnmodified,
-		DirsNew:             backupOutput.DirsNew,
-		DirsChanged:         backupOutput.DirsChanged,
-		DirsUnmodified:      backupOutput.DirsUnmodified,
-		TotalFilesProcessed: backupOutput.TotalFilesProcessed,
-		TotalBytesProcessed: backupOutput.TotalBytesProcessed,
-		SnapshotID:          backupOutput.SnapshotID,
-	}, nil
+	return backupOutput, nil
 }
 
 // BackupPipe returns a writer that streams data into a restic backup via stdin.
-func (i *Restic) BackupPipe(ctx context.Context, filename string) (io.WriteCloser, func() error, error) {
+// The returned wait func collects restic's exit status and parses the --json
+// summary it prints to stdout, so a piped backup reports the same statistics
+// (snapshot_id, file counts, processed size) as a manual backup.
+func (i *Restic) BackupPipe(ctx context.Context, filename string) (io.WriteCloser, func() (sctxt.BackupOutput, error), error) {
 	cmd, err := i.backupCmd(ctx, filename, true)
 	if err != nil {
 		return nil, nil, err
@@ -78,11 +117,28 @@ func (i *Restic) BackupPipe(ctx context.Context, filename string) (io.WriteClose
 		return nil, nil, fmt.Errorf("open stdin pipe: %w", err)
 	}
 
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+
 	if err := cmd.Start(); err != nil {
 		return nil, nil, fmt.Errorf("start restic backup: %w", err)
 	}
 
-	return writer, cmd.Wait, nil
+	wait := func() (sctxt.BackupOutput, error) {
+		if err := cmd.Wait(); err != nil {
+			return sctxt.BackupOutput{}, fmt.Errorf("wait restic backup: %w", err)
+		}
+
+		output, err := parseBackupSummary(stdout.Bytes())
+		if err != nil {
+			i.logger.Error(err)
+			return sctxt.BackupOutput{}, err
+		}
+
+		return output, nil
+	}
+
+	return writer, wait, nil
 }
 
 // IsSupportedBackupPipe reports whether piped backups are supported.

--- a/apps/strolt/internal/driver/destination/restic/backup_test.go
+++ b/apps/strolt/internal/driver/destination/restic/backup_test.go
@@ -1,0 +1,59 @@
+package restic
+
+import (
+	"testing"
+
+	"github.com/strolt/strolt/apps/strolt/internal/sctxt"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBackupSummary(t *testing.T) {
+	summaryLine := `{"message_type":"summary","files_new":1,"files_changed":0,"files_unmodified":0,` +
+		`"dirs_new":0,"dirs_changed":0,"dirs_unmodified":0,"data_blobs":1,"tree_blobs":1,` +
+		`"data_added":44040192,"total_files_processed":1,"total_bytes_processed":44040192,` +
+		`"total_duration":1.23,"snapshot_id":"a1b2c3d4"}`
+
+	expected := sctxt.BackupOutput{
+		FilesNew:            1,
+		TotalFilesProcessed: 1,
+		TotalBytesProcessed: 44040192,
+		SnapshotID:          "a1b2c3d4",
+	}
+
+	t.Run("summary after status lines with trailing newline", func(t *testing.T) {
+		output := []byte(`{"message_type":"status","percent_done":0}` + "\n" +
+			`{"message_type":"status","percent_done":0.5}` + "\n" +
+			summaryLine + "\n")
+
+		got, err := parseBackupSummary(output)
+		require.NoError(t, err)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("summary without trailing newline", func(t *testing.T) {
+		got, err := parseBackupSummary([]byte(summaryLine))
+		require.NoError(t, err)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("streamed bytes are not populated by restic summary", func(t *testing.T) {
+		got, err := parseBackupSummary([]byte(summaryLine))
+		require.NoError(t, err)
+		assert.Zero(t, got.TotalBytesStreamed)
+	})
+
+	t.Run("missing summary returns an error", func(t *testing.T) {
+		output := []byte(`{"message_type":"status","percent_done":0}` + "\n" +
+			`{"message_type":"status","percent_done":1}` + "\n")
+
+		_, err := parseBackupSummary(output)
+		require.Error(t, err)
+	})
+
+	t.Run("invalid json returns an error", func(t *testing.T) {
+		_, err := parseBackupSummary([]byte("not json"))
+		require.Error(t, err)
+	})
+}

--- a/apps/strolt/internal/driver/interfaces/interfaces.go
+++ b/apps/strolt/internal/driver/interfaces/interfaces.go
@@ -83,7 +83,7 @@ type DriverDestinationInterface interface { //nolint:interfacebloat // the drive
 	SetDriverName(driverName string)
 
 	Backup(ctx context.Context) (sctxt.BackupOutput, error)
-	BackupPipe(ctx context.Context, filename string) (writer io.WriteCloser, wait func() error, err error)
+	BackupPipe(ctx context.Context, filename string) (writer io.WriteCloser, wait func() (sctxt.BackupOutput, error), err error)
 	IsSupportedBackupPipe(ctx context.Context) bool
 
 	Restore(ctx context.Context, snapshotName string) error

--- a/apps/strolt/internal/sctxt/backup.go
+++ b/apps/strolt/internal/sctxt/backup.go
@@ -12,4 +12,8 @@ type BackupOutput struct {
 	TotalFilesProcessed uint   `json:"total_files_processed"`
 	TotalBytesProcessed uint64 `json:"total_bytes_processed"`
 	SnapshotID          string `json:"snapshot_id"`
+	// TotalBytesStreamed is the number of input bytes streamed into the
+	// destination in pipe mode. It is destination-agnostic (restic and local)
+	// and stays zero for manual/filesystem backups.
+	TotalBytesStreamed uint64 `json:"total_bytes_streamed"`
 }

--- a/apps/strolt/internal/task/backup.go
+++ b/apps/strolt/internal/task/backup.go
@@ -156,10 +156,41 @@ func (t *Task) backupPipe() error {
 	return err
 }
 
+// countingWriter wraps an io.Writer and records how many bytes were written to
+// it. io.Copy into an io.MultiWriter writes serially in a single goroutine, so a
+// plain counter is race-free without synchronization.
+type countingWriter struct {
+	w       io.Writer
+	written uint64
+}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	n, err := c.w.Write(p)
+	c.written += uint64(n) //nolint:gosec // Write never reports a negative count
+	//nolint:wrapcheck // io.Writer contract: the underlying error must pass through unchanged (io.Copy inspects it)
+	return n, err
+}
+
+// destinationPipe holds the per-destination pipe state while a piped backup is
+// streaming. Kept in a slice so streaming and cleanup order stay stable and
+// independent of map iteration order.
+type destinationPipe struct {
+	name     string
+	counter  *countingWriter
+	closer   io.Closer
+	wait     func() (sctxt.BackupOutput, error)
+	closeErr error
+}
+
 // runBackupPipe streams the source dump into every destination. The exit
 // status of the source and destination processes must fail the backup: a
 // crashed dump with a closed stream would otherwise turn into a
 // "successful" empty snapshot.
+//
+// It also emits the per-destination start/stop/error events so the report
+// includes a destination block, and it records the streamed byte count and the
+// restic summary (snapshot_id, file counts, processed size) in each
+// destination's BackupOutput.
 func (t *Task) runBackupPipe() error {
 	sourceDriver, err := t.getSourceDriver()
 	if err != nil {
@@ -178,17 +209,12 @@ func (t *Task) runBackupPipe() error {
 		_ = waitSource()
 	}()
 
-	writers := make([]io.Writer, 0, len(t.TaskConfig.Destinations))
-	closers := make([]io.Closer, 0, len(t.TaskConfig.Destinations))
-	destinationWaits := make([]func() error, 0, len(t.TaskConfig.Destinations))
+	destinations := make([]destinationPipe, 0, len(t.TaskConfig.Destinations))
 
 	defer func() {
-		for _, closer := range closers {
-			_ = closer.Close()
-		}
-
-		for _, wait := range destinationWaits {
-			_ = wait()
+		for idx := range destinations {
+			_ = destinations[idx].closer.Close()
+			_, _ = destinations[idx].wait()
 		}
 	}()
 
@@ -203,28 +229,68 @@ func (t *Task) runBackupPipe() error {
 			return fmt.Errorf("destination backup pipe: %w", err)
 		}
 
-		writers = append(writers, writer)
-		closers = append(closers, writer)
-		destinationWaits = append(destinationWaits, sync.OnceValue(destinationWait))
+		destinations = append(destinations, destinationPipe{
+			name:    destinationName,
+			counter: &countingWriter{w: writer},
+			closer:  writer,
+			wait:    sync.OnceValues(destinationWait),
+		})
+	}
+
+	// All pipes are established; announce every destination before streaming.
+	writers := make([]io.Writer, 0, len(destinations))
+
+	for idx := range destinations {
+		t.eventDestinationStart(destinations[idx].name)
+		writers = append(writers, destinations[idx].counter)
 	}
 
 	_, copyErr := io.Copy(io.MultiWriter(writers...), reader)
 
 	errs := []error{copyErr}
 
-	if err := waitSource(); err != nil {
-		errs = append(errs, fmt.Errorf("source process: %w", err))
+	sourceErr := waitSource()
+	if sourceErr != nil {
+		errs = append(errs, fmt.Errorf("source process: %w", sourceErr))
 	}
 
-	// Close the writers so the destinations see EOF before their exit
-	// status is collected.
-	for _, closer := range closers {
-		errs = append(errs, closer.Close())
+	// The source dump governs trust in the whole backup: a crashed dump yields a
+	// truncated stream that restic would still turn into a snapshot, so a source
+	// failure must fail every destination too.
+	streamErr := copyErr
+	if streamErr == nil {
+		streamErr = sourceErr
 	}
 
-	for _, wait := range destinationWaits {
-		if err := wait(); err != nil {
-			errs = append(errs, fmt.Errorf("destination process: %w", err))
+	// Close every writer first so the destinations see EOF and finalize in
+	// parallel, then collect their exit status and summary.
+	for idx := range destinations {
+		closeErr := destinations[idx].closer.Close()
+		destinations[idx].closeErr = closeErr
+
+		if closeErr != nil {
+			errs = append(errs, closeErr)
+		}
+	}
+
+	for idx := range destinations {
+		destination := &destinations[idx]
+
+		output, waitErr := destination.wait()
+		if waitErr != nil {
+			errs = append(errs, fmt.Errorf("destination process: %w", waitErr))
+		}
+
+		switch {
+		case destination.closeErr != nil || waitErr != nil:
+			t.eventDestinationError(destination.name, errors.Join(destination.closeErr, waitErr))
+
+		case streamErr != nil:
+			t.eventDestinationError(destination.name, streamErr)
+
+		default:
+			output.TotalBytesStreamed = destination.counter.written
+			t.eventDestinationStop(destination.name, output)
 		}
 	}
 

--- a/apps/strolt/internal/task/backup_test.go
+++ b/apps/strolt/internal/task/backup_test.go
@@ -1,0 +1,85 @@
+package task
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// shortWriter accepts only the first limit bytes of every Write and then
+// reports io.ErrShortWrite, mimicking a destination that stops mid-stream.
+type shortWriter struct {
+	limit int
+}
+
+func (w *shortWriter) Write(p []byte) (int, error) {
+	if len(p) <= w.limit {
+		return len(p), nil
+	}
+
+	return w.limit, io.ErrShortWrite
+}
+
+func TestCountingWriter(t *testing.T) {
+	t.Run("counts bytes and forwards them to the underlying writer", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		cw := &countingWriter{w: &buf}
+
+		payload := []byte("hello world")
+
+		n, err := cw.Write(payload)
+		require.NoError(t, err)
+		assert.Equal(t, len(payload), n)
+
+		n, err = cw.Write(payload)
+		require.NoError(t, err)
+		assert.Equal(t, len(payload), n)
+
+		assert.Equal(t, uint64(2*len(payload)), cw.written)
+		assert.Equal(t, "hello worldhello world", buf.String())
+	})
+
+	t.Run("counts only the bytes accepted on a short write", func(t *testing.T) {
+		cw := &countingWriter{w: &shortWriter{limit: 3}}
+
+		n, err := cw.Write([]byte("hello"))
+		require.ErrorIs(t, err, io.ErrShortWrite)
+		assert.Equal(t, 3, n)
+		assert.Equal(t, uint64(3), cw.written)
+	})
+
+	t.Run("io.Copy through the writer records the full stream size", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		cw := &countingWriter{w: &buf}
+
+		payload := bytes.Repeat([]byte("x"), 4096)
+
+		written, err := io.Copy(cw, bytes.NewReader(payload))
+		require.NoError(t, err)
+		assert.Equal(t, int64(len(payload)), written)
+		assert.Equal(t, uint64(len(payload)), cw.written)
+	})
+
+	t.Run("propagates an underlying writer error", func(t *testing.T) {
+		wantErr := errors.New("boom")
+
+		cw := &countingWriter{w: writerFunc(func(p []byte) (int, error) {
+			return 0, wantErr
+		})}
+
+		n, err := cw.Write([]byte("data"))
+		require.ErrorIs(t, err, wantErr)
+		assert.Zero(t, n)
+		assert.Zero(t, cw.written)
+	})
+}
+
+type writerFunc func(p []byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (int, error) { return f(p) }

--- a/apps/strolt/internal/template/template.go
+++ b/apps/strolt/internal/template/template.go
@@ -139,6 +139,10 @@ func New(driver string, ctx context.Context) Template { //nolint:revive // ctx i
 		if destination.BackupOutput.TotalBytesProcessed != 0 {
 			t.Body += "\n    total_size_processed: " + humanize.Bytes(destination.BackupOutput.TotalBytesProcessed)
 		}
+
+		if destination.BackupOutput.TotalBytesStreamed != 0 {
+			t.Body += "\n    streamed_size: " + humanize.Bytes(destination.BackupOutput.TotalBytesStreamed)
+		}
 	}
 
 	return t

--- a/apps/strolt/internal/template/template_test.go
+++ b/apps/strolt/internal/template/template_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/strolt/strolt/apps/strolt/internal/context"
 	"github.com/strolt/strolt/apps/strolt/internal/sctxt"
 
+	"github.com/dustin/go-humanize"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -141,6 +142,46 @@ func TestNew(t *testing.T) {
 		body += "\nStop: " + stopTime.Format(time.RFC3339)
 		body += fmt.Sprintf("\nDuration: %s", stopTime.Sub(startTime))
 		body += fmt.Sprintf("\n\nError: %s", err)
+
+		assert.Equal(t, body, tmpl.Body)
+	})
+
+	t.Run("destination block with restic summary and streamed size", func(t *testing.T) {
+		const streamedBytes = uint64(44040192)
+
+		tmpl := New("", context.Context{
+			TaskName:       taskName,
+			OpertationType: sctxt.OpTypeBackup,
+			Event:          sctxt.EvOperationStop,
+			Operation: context.Operation{
+				Time: context.Time{
+					Start: startTime,
+					Stop:  stopTime,
+				},
+			},
+			Destination: map[string]context.DestinationOperation{
+				"main": {
+					BackupOutput: sctxt.BackupOutput{
+						FilesNew:            1,
+						TotalFilesProcessed: 1,
+						TotalBytesProcessed: streamedBytes,
+						SnapshotID:          "a1b2c3d4",
+						TotalBytesStreamed:  streamedBytes,
+					},
+				},
+			},
+		})
+
+		body := fmt.Sprintf(`Event: %s`, sctxt.EvOperationStop)
+		body += "\nStart: " + startTime.Format(time.RFC3339)
+		body += "\nStop: " + stopTime.Format(time.RFC3339)
+		body += fmt.Sprintf("\nDuration: %s", stopTime.Sub(startTime))
+		body += "\n\n[destination] main:"
+		body += "\n    snapshot_id: a1b2c3d4"
+		body += "\n    files_new: " + commaUint(1)
+		body += "\n    total_files_processed: " + commaUint(1)
+		body += "\n    total_size_processed: " + humanize.Bytes(streamedBytes)
+		body += "\n    streamed_size: " + humanize.Bytes(streamedBytes)
 
 		assert.Equal(t, body, tmpl.Body)
 	})


### PR DESCRIPTION
## Problem

Piped (stdin) backups only emitted operation-level events, so the notification
report showed nothing below the header (operation / start / stop / duration):
no size, no destination block, no `snapshot_id`. This affected **every** pipe
source (postgres, mysql, mongodb), since they all go through the same code path.

Root causes:
1. `runBackupPipe()` discarded the `io.Copy` byte count and never measured the
   destination writers.
2. `backupPipe()` emitted only operation-level events, never
   `eventDestinationStart/Stop/Error`, so `ctx.Destination` stayed empty and the
   template rendered no per-destination block.
3. `Restic.BackupPipe` never set `cmd.Stdout`, so restic's `--json` summary
   (snapshot_id, files, processed bytes) was thrown away.

## Change — "bytes + restic summary"

- **Count streamed input bytes per destination** with a small counting writer and
  surface them as `streamed_size`. Destination-agnostic — works for restic and
  local.
- **Capture restic's `--json` summary in pipe mode** and populate
  `sctxt.BackupOutput` (snapshot_id, file counts, processed size) so the piped
  report matches the manual/filesystem report. The summary parsing/mapping is
  shared with the manual `Backup()` path.
- **Emit destination start/stop/error events in pipe mode** so the
  per-destination block is rendered in reports/notifications.

The destination `BackupPipe` wait signature now returns
`(sctxt.BackupOutput, error)`; the restic driver, the local driver and the
driver interface are updated accordingly. `sctxt.BackupOutput` gains an additive,
back-compatible `TotalBytesStreamed` field. The manual/filesystem flow is
unchanged, and the existing close/wait ordering (a crashed dump must still fail
the backup) is preserved.

Resulting pipe report for a `pg -> restic` backup:

```
[destination] main:
    snapshot_id: a1b2c3d4
    files_new: 1
    total_files_processed: 1
    total_size_processed: 42 MB   (from restic summary)
    streamed_size: 42 MB          (counted input bytes)
```

## Testing

- `go build ./...`, `go vet ./...` — clean.
- New unit tests: `parseBackupSummary` (restic summary extraction),
  `countingWriter` (byte counting), and the destination-block rendering with
  `streamed_size` (template). All internal tests pass, including with `-race`.
- `golangci-lint` (project-pinned v2.12.2) on the whole module — 0 issues.
- e2e `pg -> restic` pipe suite passes end-to-end (`pipe_t`, `pipe_p`, `pipe_c`;
  `pipe_d` is skipped as directory format does not support pipe).
- Verified `parseBackupSummary` against the real restic 0.19.0 binary output
  (`restic backup --stdin --json`).
