### PR TITLE
fix(strolt): parse restic stats output with a progress line

### DIFF
--- a/apps/strolt/internal/driver/destination/restic/stats.go
+++ b/apps/strolt/internal/driver/destination/restic/stats.go
@@ -3,8 +3,11 @@ package restic
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
+	"slices"
+	"strings"
 
 	"github.com/strolt/strolt/apps/strolt/internal/driver/interfaces"
 )
@@ -13,6 +16,29 @@ type resticStats struct {
 	TotalSize      uint64 `json:"total_size"`
 	TotalFileCount uint64 `json:"total_file_count"`
 	SnapshotsCount int    `json:"snapshots_count"`
+}
+
+// parseStats extracts the stats object from restic's --json stats output.
+// restic prints a scan-progress line (e.g. "[0:00] 100.00%  2 / 2 snapshots")
+// to stdout before the JSON object, so the whole output is not valid JSON on
+// its own. Scan from the end for the line holding the JSON object and ignore
+// the progress line.
+func parseStats(output []byte) (resticStats, error) {
+	for _, line := range slices.Backward(strings.Split(string(output), "\n")) {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "{") {
+			continue
+		}
+
+		var stats resticStats
+		if err := json.Unmarshal([]byte(line), &stats); err != nil {
+			return resticStats{}, fmt.Errorf("unmarshal stats output: %w", err)
+		}
+
+		return stats, nil
+	}
+
+	return resticStats{}, errors.New("restic stats output not found")
 }
 
 // Stats returns repository statistics reported by restic.
@@ -37,16 +63,16 @@ func (i *Restic) Stats() (interfaces.Stats, error) {
 		return interfaces.Stats{}, err
 	}
 
-	resticStats := resticStats{}
-	if err := json.Unmarshal(output, &resticStats); err != nil {
+	parsed, err := parseStats(output)
+	if err != nil {
 		i.logger.Error(err)
-		return interfaces.Stats{}, fmt.Errorf("unmarshal stats output: %w", err)
+		return interfaces.Stats{}, err
 	}
 
 	stats := interfaces.Stats{
-		TotalSize:      resticStats.TotalSize,
-		TotalFileCount: resticStats.TotalFileCount,
-		SnapshotsCount: resticStats.SnapshotsCount,
+		TotalSize:      parsed.TotalSize,
+		TotalFileCount: parsed.TotalFileCount,
+		SnapshotsCount: parsed.SnapshotsCount,
 	}
 
 	return stats, nil

--- a/apps/strolt/internal/driver/destination/restic/stats_test.go
+++ b/apps/strolt/internal/driver/destination/restic/stats_test.go
@@ -1,0 +1,42 @@
+package restic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseStats(t *testing.T) {
+	expected := resticStats{
+		TotalSize:      8,
+		TotalFileCount: 2,
+		SnapshotsCount: 2,
+	}
+
+	t.Run("json object preceded by a progress line", func(t *testing.T) {
+		// restic 0.19 prints a scan-progress line to stdout before the JSON.
+		output := []byte("[0:00] 100.00%  2 / 2 snapshots, 1 files, 4 B\n" +
+			`{"total_size":8,"total_file_count":2,"snapshots_count":2}` + "\n")
+
+		got, err := parseStats(output)
+		require.NoError(t, err)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("json object only, without trailing newline", func(t *testing.T) {
+		got, err := parseStats([]byte(`{"total_size":8,"total_file_count":2,"snapshots_count":2}`))
+		require.NoError(t, err)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("missing json object returns an error", func(t *testing.T) {
+		_, err := parseStats([]byte("[0:00] 100.00%  0 / 0 snapshots\n"))
+		require.Error(t, err)
+	})
+
+	t.Run("malformed json object returns an error", func(t *testing.T) {
+		_, err := parseStats([]byte("{not json}"))
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Problem

Requesting destination stats aborted with:

```
ERROR invalid character ':' after array element  driver=restic driverType=destination ...
FATAL get destination stats: unmarshal stats output: invalid character ':' after array element
```

restic 0.19 prints a scan-progress line to **stdout** before the `--json` stats
object:

```
[0:00] 100.00%  2 / 2 snapshots, 1 files, 4 B
{"total_size":8,"total_file_count":2,"snapshots_count":2}
```

`Stats()` unmarshalled the **whole** output, so the decoder parsed the leading
`[0:00]` as a JSON array and hit `:` after the first element — hence
`invalid character ':' after array element`. Older restic versions did not emit
this line, so the bug surfaced only after the restic upgrade.

## Fix

Extract the JSON object from the stats output by scanning lines from the end and
skipping the progress line (mirrors the backup-summary parsing). `restic stats
-q --json` does **not** suppress the progress line, so robust parsing — not a
flag — is the fix.

Only `Stats()` is affected: `restic --json snapshots` emits a clean JSON array
with no progress line, so `Snapshots()` is unchanged.

## Testing

- New unit test `TestParseStats` covering the real restic 0.19 output (progress
  line + JSON object), a bare JSON object, and malformed/missing cases.
- `go build ./...`, `go vet`, full non-e2e `go test` — pass.
- `golangci-lint` (project-pinned v2.12.2) — 0 issues.
- Verified the exact output against the real restic 0.19.0 binary
  (`restic --json stats`).
